### PR TITLE
Centre author text

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -8,6 +8,7 @@
 
 .authors>span {
     padding: 0 0.5rem;
+    display: inline-block;
 }
 
 @media only screen and (max-width: 480px) {


### PR DESCRIPTION
Not totally sure why this is needed, but on mobile (iPhone 11) the author text is still off centre even after fixing the padding.  Adding `display: inline-block` seems to fix it. The top line in the images below is most obvious.

Without:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/6437437/136689790-58893d28-9471-42fc-970c-fdf2173384b1.png">

With:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/6437437/136689806-020c819f-2731-4a6a-9f3a-fb380499bc29.png">
