### PR TITLE
Justify text

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -147,7 +147,7 @@
                     <video class="mb-3 is-16by9" width="100%" autoplay muted loop playsinline>
                         <source src="video/face_parsing.mp4" type="video/mp4">
                     </video>
-                    <p>
+                    <p class="has-text-justified-mobile">
                         Pixel-perfect segmentation labels let us achieve near-SOTA results using off-the-shelf neural networks.
                     </p>
                 </div>
@@ -158,7 +158,7 @@
                     <video class="mb-3 is-16by9" width="100%" autoplay muted loop playsinline>
                         <source src="video/dense_landmarks.mp4" type="video/mp4">
                     </video>
-                    <p>
+                    <p class="has-text-justified-mobile">
                         With synthetic landmark labels, its easy to predict ten times as many landmarks as usual.
                     </p>
                 </div>
@@ -186,13 +186,13 @@
             <div class="columns mt-4">
                 <div class="column">
                     <img class="mb-3" src="img/iccv21_identity_samples.png" />
-                    <p>
+                    <p class="has-text-justified-mobile">
                         Identities sampled from our generative model. We trained this model on a diverse set of high quality scan data.
                     </p>
                 </div>
                 <div class="column">
                     <img class="mb-3" src="img/iccv21_expression_samples.png" />
-                    <p>
+                    <p class="has-text-justified-mobile">
                         We randomly pick facial expressions from our performance capture database of 70,000 frames.
                     </p>
                 </div>
@@ -200,11 +200,11 @@
         </div>
     </section>
     <section class="section pt-0">
-        <div class="container is-max-desktop has-text-justified">
+        <div class="container is-max-desktop">
             <h1 class="title is-4">
                 Diversity
             </h1>
-            <div class="content">
+            <div class="content has-text-justified">
                 <img class="mb-3" src="img/muct_9x2.jpg" />
                 <p>
                     Synthetically-trained machine learning models should work well across the human population.
@@ -219,7 +219,7 @@
                     <img class="mb-3" src="img/face-model-data-stats.png" />
                 </div>
                 <div class="column">
-                    <div class="content">
+                    <div class="content has-text-justified">
                         <p>
                             In order to generate diverse synthetic data, our generative models must be trained with diverse source data.
                         </p>


### PR DESCRIPTION
Bit of personal choice on style, but I prefer justified text:

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/6437437/136690114-70e4883e-4aa1-435c-945c-ae81677fc56a.png">

rather than left aligned as it is now
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/6437437/136690132-1a2d95c6-f7e8-4747-b074-18854275f091.png">
