### PR TITLE
Video playsinline

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -146,7 +146,7 @@
                     <h1 class="title is-5">
                         Face Parsing
                     </h1>
-                    <video class="mb-3 is-16by9" width="100%" autoplay muted loop>
+                    <video class="mb-3 is-16by9" width="100%" autoplay muted loop playsinline>
                         <source src="video/face_parsing.mp4" type="video/mp4">
                     </video>
                     <p>
@@ -157,7 +157,7 @@
                     <h1 class="title is-5">
                         Dense Landmarks
                     </h1>
-                    <video class="mb-3 is-16by9" width="100%" autoplay muted loop>
+                    <video class="mb-3 is-16by9" width="100%" autoplay muted loop playsinline>
                         <source src="video/dense_landmarks.mp4" type="video/mp4">
                     </video>
                     <p>


### PR DESCRIPTION
Adding playsinline to video tags let them play inline on iOS, otherwise we just get the first frame as an image as the controls aren't enabled (haven't tested on my phone, but should work)